### PR TITLE
Enable lexical binding

### DIFF
--- a/uuidgen.el
+++ b/uuidgen.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kan-Ru Chen <kanru@kanru.info>
 ;; Created: 08 Nov 2010
-;; Version: 1.2
+;; Version: 1.3
 ;; Keywords: extensions, lisp, tools
 
 ;; This file is NOT part of GNU Emacs.

--- a/uuidgen.el
+++ b/uuidgen.el
@@ -1,4 +1,4 @@
-;;; uuidgen.el --- Provides various UUID generating functions
+;;; uuidgen.el --- Provides various UUID generating functions -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2010, 2011, 2014, 2020, 2022 Kan-Ru Chen
 


### PR DESCRIPTION
Hi. In Emacs30, not having lexical binding is now a byte compiler warning. I have been using this package for some time with lexical binding enabled and have not encountered any issues nor do I see anything in the code that could cause problems with that.

If any problems do arise, feel free to ping me and I will follow up this PR.